### PR TITLE
Complexe showcase

### DIFF
--- a/config/config.json
+++ b/config/config.json
@@ -1,5 +1,8 @@
 {
     "tcServer": {
         "url": "http://localhost:3000"
+    },
+    "tcSlave": {
+        "keysBlocked": ["ArrowDown", "ArrowUp", "ArrowLeft", "ArrowRight", "Space"]
     }
 }

--- a/showcase/reveal/demo.html
+++ b/showcase/reveal/demo.html
@@ -35,7 +35,7 @@
 	</head>
 
 	<body>
-
+        <script src="../assets/slave/index.js"></script>
 		<div class="reveal">
 
 			<!-- Any section element inside of this container is displayed as a slide -->

--- a/src/client/engines/generic-client-engine.js
+++ b/src/client/engines/generic-client-engine.js
@@ -29,4 +29,9 @@ export class GenericEngine {
      * @param {number} delta - number of movements to make from$ the current slide
      */
     changeSlide(delta) {}
+
+    /**
+     * Tell if the active element in DOM is an editable one
+     */
+    isActiveElementEditable() {}
 }

--- a/src/client/engines/revealjs-client-engine.js
+++ b/src/client/engines/revealjs-client-engine.js
@@ -42,14 +42,18 @@ export class RevealEngine extends GenericEngine {
         let slideDelta = { ...indices };
         const slides = this.getSlides();
         const currentIndex = slides.findIndex(slide => slide.h === indices.h && slide.v === indices.v);
-        if (indices.f < slides[currentIndex].fMax) {
+        if (indices.f + delta < slides[currentIndex].fMax) {
             slideDelta.f += delta;
         } else if (currentIndex + delta < slides.length - 1) {
             slideDelta = slides[currentIndex + delta];
         } else {
             slideDelta = slides[slides.length - 1];
         }
-        this.Reveal.slide(slideDelta.h, slideDelta.v, slideDelta.f || 0);
+        if (!delta) {
+            console.log(indices.f, slides[currentIndex].fMax);
+            console.log('Going to slide:', slideDelta);
+        }
+        this.Reveal.slide(slideDelta.h, slideDelta.v, slideDelta.f);
     }
 
     /**
@@ -64,10 +68,10 @@ export class RevealEngine extends GenericEngine {
             if (verticalSlides.length) {
                 verticalSlides.forEach((slideV, indexV) => {
                     const fragmentsV = slideV.querySelectorAll('.fragment');
-                    slides.push({ h: indexH, v: indexV, f: 0, fMax: fragmentsV.length ? fragmentsV.length + 1 : 0 });
+                    slides.push({ h: indexH, v: indexV, f: -1, fMax: fragmentsV.length || -1 });
                 });
             } else {
-                slides.push({ h: indexH, v: 0, f: 0, fMax: fragmentsH.length ? fragmentsH.length + 1 : 0 });
+                slides.push({ h: indexH, v: 0, f: -1, fMax: fragmentsH.length || -1 });
             }
         });
         return slides;

--- a/src/client/engines/revealjs-client-engine.js
+++ b/src/client/engines/revealjs-client-engine.js
@@ -76,4 +76,11 @@ export class RevealEngine extends GenericEngine {
     getSlideNotes() {
         return this.Reveal.getSlideNotes();
     }
+
+    /**
+     * @returns {boolean} True if the active element is editable
+     */
+    isActiveElementEditable() {
+        return document.activeElement && document.activeElement.contentEditable !== 'inherit';
+    }
 }

--- a/src/client/engines/revealjs-client-engine.js
+++ b/src/client/engines/revealjs-client-engine.js
@@ -27,7 +27,7 @@ export class RevealEngine extends GenericEngine {
             transitionSpeed: 'fast',
             history: false,
             slideNumber: false,
-            keyboard: false,
+            keyboard: true,
             touch: false,
             embedded: true
         });

--- a/src/client/engines/revealjs-client-engine.js
+++ b/src/client/engines/revealjs-client-engine.js
@@ -49,10 +49,6 @@ export class RevealEngine extends GenericEngine {
         } else {
             slideDelta = slides[slides.length - 1];
         }
-        if (!delta) {
-            console.log(indices.f, slides[currentIndex].fMax);
-            console.log('Going to slide:', slideDelta);
-        }
         this.Reveal.slide(slideDelta.h, slideDelta.v, slideDelta.f);
     }
 
@@ -79,13 +75,5 @@ export class RevealEngine extends GenericEngine {
 
     getSlideNotes() {
         return this.Reveal.getSlideNotes();
-    }
-
-    /**
-     *
-     * @param {number} delta - number of movements to make from$ the current slide
-     */
-    changeSlide(delta) {
-        this.goToSlide(this.Reveal.getIndices(), delta);
     }
 }

--- a/src/client/layouts/common/slide-view/slide-view.js
+++ b/src/client/layouts/common/slide-view/slide-view.js
@@ -36,9 +36,14 @@ class SlideView extends LitElement {
         // For debug purposes - called each time a property value changes
         console.log('attribute change: ', name, newval);
         super.attributeChangedCallback(name, oldval, newval);
+
         if (newval && (name === 'url' || (this.url && name === 'delta'))) {
             const iframe = this.shadowRoot.querySelector('iframe');
-            iframe.src = `${newval}#delta=${this.delta}`;
+            let src = `${this.url}#delta=${this.delta}`;
+            if (this.focus) {
+                src += '&focus';
+            }
+            iframe.src = src;
             iframe.classList.remove('is-hidden');
         }
     }

--- a/src/client/layouts/on-stage/on-stage.html
+++ b/src/client/layouts/on-stage/on-stage.html
@@ -17,7 +17,7 @@
         <section class="columns is-gapless" style="margin-bottom: 0;">
             <div class="column" id="slide">
                 <div class="content">
-                    <tc-slide class="is-hidden"></tc-slide>
+                    <tc-slide class="is-hidden" focus></tc-slide>
                 </div>
             </div>
         </section>

--- a/src/client/layouts/presenter/presenter.html
+++ b/src/client/layouts/presenter/presenter.html
@@ -19,7 +19,7 @@
         <section class="columns is-marginless is-paddingless is-hidden" id="presenter-view">
             <div class="column is-three-fifths" id="current">
                 <div class="content">
-                    <tc-slide></tc-slide>
+                    <tc-slide focus></tc-slide>
                 </div>
             </div>
             <div class="column is-paddingless has-background-light">

--- a/src/client/talk-control-slave/index.js
+++ b/src/client/talk-control-slave/index.js
@@ -4,11 +4,29 @@ import { TalkControlSlave } from './talk-control-slave';
 
 window.addEventListener('DOMContentLoaded', function() {
     const hash = window.location.hash || '#delta=0';
-    const delta = Number(hash.trim('#').split('=')[1]);
+    const params = parseParams(hash);
     // TODO: retrieve engineName from configuration
-    new TalkControlSlave({ engineName: 'revealjs', delta });
-    // Give the focus back to parent each time it goes to the iframe
-    document.addEventListener('click', () => {
-        parent.focus();
-    });
+    new TalkControlSlave({ engineName: 'revealjs', ...params });
 });
+
+const parseParams = hash => {
+    const paramsTab = hash.replace('#', '').split('&');
+    const params = {};
+    for (const paramStr of paramsTab) {
+        let [key, value] = paramStr.split('=');
+        if (Array.isArray(value)) {
+            console.warn(`value given for key ${key} are badly formated`, value);
+            value = value[0];
+        }
+        switch (true) {
+            case !value:
+                value = true;
+                break;
+            case !isNaN(value):
+                value = parseInt(value);
+                break;
+        }
+        params[key] = value;
+    }
+    return params;
+};

--- a/src/client/talk-control-slave/talk-control-slave.js
+++ b/src/client/talk-control-slave/talk-control-slave.js
@@ -37,6 +37,11 @@ export class TalkControlSlave {
 
     _captureKeyboardEvent(event, forward = false) {
         const keys = config.tcSlave.keysBlocked;
+        // Check if there's a focused element that could be using
+        // the keyboard
+        const activeElementIsInput = document.activeElement && document.activeElement.tagName && /input|textarea/i.test(document.activeElement.tagName);
+        if (this.engine.isActiveElementEditable() || activeElementIsInput) return;
+        // Check if the pressed key should be interpreted
         if (keys.includes(event.code)) {
             event.stopPropagation();
             if (forward) this.eventBus.emit(MASTER_SLAVE_CHANNEL, 'keyboardEvent', { key: event.key, code: event.code });

--- a/src/client/talk-control-slave/talk-control-slave.js
+++ b/src/client/talk-control-slave/talk-control-slave.js
@@ -2,6 +2,7 @@
 
 import { EventBusResolver, MASTER_SLAVE_CHANNEL } from '@event-bus/event-bus-resolver';
 import { EngineResolver } from '../engines/engine-resolver';
+import config from '@config/config.json';
 
 export class TalkControlSlave {
     constructor(params = {}) {
@@ -13,6 +14,7 @@ export class TalkControlSlave {
         this.delta = params.delta || 0;
         this.engine = EngineResolver.getEngine(params.engineName);
         this.eventBus.on(MASTER_SLAVE_CHANNEL, 'init', this.init.bind(this));
+        this._captureKeyboardEvent = this._captureKeyboardEvent.bind(this);
     }
 
     init() {
@@ -27,5 +29,17 @@ export class TalkControlSlave {
                 this.eventBus.emit(MASTER_SLAVE_CHANNEL, 'sendNotesToMaster', this.engine.getSlideNotes());
             }
         });
+        // Capture all keyboards events and only let go the ones that are not interpreted by us
+        addEventListener('keyup', e => this._captureKeyboardEvent(e, true), true);
+        addEventListener('keypressed', this._captureKeyboardEvent, true);
+        addEventListener('keydown', this._captureKeyboardEvent, true);
+    }
+
+    _captureKeyboardEvent(event, forward = false) {
+        const keys = config.tcSlave.keysBlocked;
+        if (keys.includes(event.code)) {
+            event.stopPropagation();
+            if (forward) this.eventBus.emit(MASTER_SLAVE_CHANNEL, 'keyboardEvent', { key: event.key, code: event.code });
+        }
     }
 }

--- a/src/server/engines/revealjs-server-engine.js
+++ b/src/server/engines/revealjs-server-engine.js
@@ -33,25 +33,28 @@ export class RevealEngine extends GenericEngine {
         const { fMax } = slides[currentSlideIndex];
         const nextVerticalSlide = slides.find(slide => currentSlide.h === slide.h && slide.v === currentSlide.v + 1);
         const nextHorizontalSlide = slides.find(slide => currentSlide.h + 1 === slide.h);
+        console.log('handle input: ', key);
+        console.log(fMax, currentSlide, currentSlide.f < fMax);
+
         switch (key) {
             case 'arrowRight':
-                if (currentSlide.f < fMax) this._nextFragment(currentSlide);
+                if (currentSlide.f < fMax - 1) this._nextFragment(currentSlide);
                 else if (nextHorizontalSlide) this._nextHorizontalSlide(currentSlide);
                 break;
             case 'arrowLeft':
-                if (currentSlide.f > 0) this._prevFragment(currentSlide);
+                if (currentSlide.f > -1) this._prevFragment(currentSlide);
                 else if (currentSlideIndex) this._prevHorizontalSlide(currentSlide);
                 break;
             case 'arrowUp':
-                if (currentSlide.f > 0) this._prevFragment(currentSlide);
+                if (currentSlide.f > -1) this._prevFragment(currentSlide);
                 else if (currentSlide.v > 0) this._prevVerticalSlide(currentSlide);
                 break;
             case 'arrowDown':
-                if (currentSlide.f < fMax) this._nextFragment(currentSlide);
+                if (currentSlide.f < fMax - 1) this._nextFragment(currentSlide);
                 else if (nextVerticalSlide) this._nextVerticalSlide(currentSlide);
                 break;
             case 'space':
-                if (currentSlide.f < fMax) this._nextFragment(currentSlide);
+                if (currentSlide.f < fMax - 1) this._nextFragment(currentSlide);
                 else if (nextVerticalSlide) this._nextVerticalSlide(currentSlide);
                 else if (nextHorizontalSlide) this._nextHorizontalSlide(currentSlide);
                 break;
@@ -77,19 +80,19 @@ export class RevealEngine extends GenericEngine {
      */
 
     _nextHorizontalSlide({ h }) {
-        store.dispatch(gotoSlide({ h: h + 1, v: 0 }));
+        store.dispatch(gotoSlide({ h: h + 1, v: 0, f: -1 }));
     }
 
     _nextVerticalSlide({ h, v }) {
-        store.dispatch(gotoSlide({ h, v: v + 1 }));
+        store.dispatch(gotoSlide({ h, v: v + 1, f: -1 }));
     }
 
     _prevHorizontalSlide({ h }) {
-        store.dispatch(gotoSlide({ h: h - 1, v: 0 }));
+        store.dispatch(gotoSlide({ h: h - 1, v: 0, f: -1 }));
     }
 
     _prevVerticalSlide({ h, v }) {
-        store.dispatch(gotoSlide({ h, v: v - 1 }));
+        store.dispatch(gotoSlide({ h, v: v - 1, f: -1 }));
     }
 
     _nextFragment({ h, v, f }) {

--- a/src/server/engines/revealjs-server-engine.js
+++ b/src/server/engines/revealjs-server-engine.js
@@ -21,7 +21,7 @@ export class RevealEngine extends GenericEngine {
      * @param {*} params - Needed params to initialize the engine
      */
     init(params) {
-        store.dispatch(init({ ...params, currentSlide: { h: 0, v: 0, f: 0 } }));
+        store.dispatch(init({ ...params, currentSlide: { h: 0, v: 0, f: -1 } }));
     }
 
     /**
@@ -33,8 +33,8 @@ export class RevealEngine extends GenericEngine {
         const { fMax } = slides[currentSlideIndex];
         const nextVerticalSlide = slides.find(slide => currentSlide.h === slide.h && slide.v === currentSlide.v + 1);
         const nextHorizontalSlide = slides.find(slide => currentSlide.h + 1 === slide.h);
-        console.log('handle input: ', key);
-        console.log(fMax, currentSlide, currentSlide.f < fMax);
+        const prevVerticalSlide = slides.find(slide => currentSlide.h === slide.h && slide.v === currentSlide.v - 1);
+        const prevHorizontalSlide = slides.find(slide => currentSlide.h - 1 === slide.h);
 
         switch (key) {
             case 'arrowRight':
@@ -43,11 +43,11 @@ export class RevealEngine extends GenericEngine {
                 break;
             case 'arrowLeft':
                 if (currentSlide.f > -1) this._prevFragment(currentSlide);
-                else if (currentSlideIndex) this._prevHorizontalSlide(currentSlide);
+                else if (prevHorizontalSlide) this._prevSlide(prevHorizontalSlide);
                 break;
             case 'arrowUp':
                 if (currentSlide.f > -1) this._prevFragment(currentSlide);
-                else if (currentSlide.v > 0) this._prevVerticalSlide(currentSlide);
+                else if (prevVerticalSlide) this._prevSlide(prevVerticalSlide);
                 break;
             case 'arrowDown':
                 if (currentSlide.f < fMax - 1) this._nextFragment(currentSlide);
@@ -80,26 +80,26 @@ export class RevealEngine extends GenericEngine {
      */
 
     _nextHorizontalSlide({ h }) {
-        store.dispatch(gotoSlide({ h: h + 1, v: 0, f: -1 }));
+        this._gotoSlide({ h: h + 1, v: 0, f: -1 });
     }
 
     _nextVerticalSlide({ h, v }) {
-        store.dispatch(gotoSlide({ h, v: v + 1, f: -1 }));
+        this._gotoSlide({ h, v: v + 1, f: -1 });
     }
 
-    _prevHorizontalSlide({ h }) {
-        store.dispatch(gotoSlide({ h: h - 1, v: 0, f: -1 }));
-    }
-
-    _prevVerticalSlide({ h, v }) {
-        store.dispatch(gotoSlide({ h, v: v - 1, f: -1 }));
+    _prevSlide({ h, v, fMax }) {
+        this._gotoSlide({ h, v, f: fMax > 0 ? fMax - 1 : fMax });
     }
 
     _nextFragment({ h, v, f }) {
-        store.dispatch(gotoSlide({ h, v, f: f + 1 }));
+        this._gotoSlide({ h, v, f: f + 1 });
     }
 
     _prevFragment({ h, v, f }) {
-        store.dispatch(gotoSlide({ h, v, f: f - 1 }));
+        this._gotoSlide({ h, v, f: f - 1 });
+    }
+
+    _gotoSlide(slide) {
+        store.dispatch(gotoSlide(slide));
     }
 }

--- a/src/server/talk-control-server.js
+++ b/src/server/talk-control-server.js
@@ -29,7 +29,7 @@ export class TalkControlServer {
     init(engineName) {
         this.engine = EngineResolver.getEngine(engineName);
         this.eventBus.on(MASTER_SERVER_CHANNEL, 'init', this.engine.init);
-        this.eventBus.on(MASTER_SERVER_CHANNEL, 'keyPressed', this.engine.handleInput);
+        this.eventBus.on(MASTER_SERVER_CHANNEL, 'keyboardEvent', this.engine.handleInput);
         store.subscribe(this.emitStateChanges.bind(this));
     }
 

--- a/test/client/engines/revealjs-client-engine.spec.js
+++ b/test/client/engines/revealjs-client-engine.spec.js
@@ -41,7 +41,7 @@ describe('RevealEngineClient', function() {
     describe('goToSlide()', function() {
         it('should call Reveal.slide() with the given params', function() {
             // Given
-            stub(engine, 'getSlides').returns([{ h: 1, v: 1, f: 0, fMax: 0 }, { h: 1, v: 2, f: 0, fMax: 4 }]);
+            stub(engine, 'getSlides').returns([{ h: 1, v: 1, f: -1, fMax: -1 }, { h: 1, v: 2, f: -1, fMax: 4 }]);
             // When
             engine.goToSlide({ h: 1, v: 2, f: 3 });
             // Then
@@ -58,7 +58,7 @@ describe('RevealEngineClient', function() {
             const slides = engine.getSlides();
             // Then
             expect(slides.length).to.equals(3);
-            expect(slides[0]).to.eqls({ h: 0, v: 0, f: 0, fMax: 0 });
+            expect(slides[0]).to.eqls({ h: 0, v: 0, f: -1, fMax: -1 });
             document.querySelectorAll.restore();
         });
     });

--- a/test/client/talk-control-master/talk-control-master.spec.js
+++ b/test/client/talk-control-master/talk-control-master.spec.js
@@ -39,6 +39,7 @@ describe('', function() {
             stub(talkControlMaster, 'forwardEvents');
 
             talkControlMaster.frames = [{}, {}, {}];
+            talkControlMaster.focusFrame = { focus: stub() };
             // When
             talkControlMaster.init();
             talkControlMaster.frames.forEach(frame => frame.onload());
@@ -48,7 +49,7 @@ describe('', function() {
         });
     });
 
-    describe('_onKeyUp', function() {
+    describe('onKeyboardEvent', function() {
         let mainChannel;
         beforeEach(function() {
             // Event mock
@@ -65,9 +66,9 @@ describe('', function() {
             const event = new Event('keyup');
             event.key = 'ArrowUp';
             // When
-            talkControlMaster._onKeyUp(event);
+            talkControlMaster.onKeyboardEvent(event);
             // Then
-            assert(mainChannel.emit.calledOnceWith('keyPressed', { key: 'arrowUp' }));
+            assert(mainChannel.emit.calledOnceWith('keyboardEvent', { key: 'arrowUp' }));
         });
 
         it('should fire "arrowDown" event', function() {
@@ -75,9 +76,9 @@ describe('', function() {
             const event = new Event('keyup');
             event.key = 'ArrowDown';
             // When
-            talkControlMaster._onKeyUp(event);
+            talkControlMaster.onKeyboardEvent(event);
             // Then
-            assert(mainChannel.emit.calledOnceWith('keyPressed', { key: 'arrowDown' }));
+            assert(mainChannel.emit.calledOnceWith('keyboardEvent', { key: 'arrowDown' }));
         });
 
         it('should fire "arrowLeft" event', function() {
@@ -85,9 +86,9 @@ describe('', function() {
             const event = new Event('keyup');
             event.key = 'ArrowLeft';
             // When
-            talkControlMaster._onKeyUp(event);
+            talkControlMaster.onKeyboardEvent(event);
             // Then
-            assert(mainChannel.emit.calledOnceWith('keyPressed', { key: 'arrowLeft' }));
+            assert(mainChannel.emit.calledOnceWith('keyboardEvent', { key: 'arrowLeft' }));
         });
 
         it('should fire "arrowRight" event', function() {
@@ -95,9 +96,9 @@ describe('', function() {
             const event = new Event('keyup');
             event.key = 'ArrowRight';
             // When
-            talkControlMaster._onKeyUp(event);
+            talkControlMaster.onKeyboardEvent(event);
             // Then
-            assert(mainChannel.emit.calledOnceWith('keyPressed', { key: 'arrowRight' }));
+            assert(mainChannel.emit.calledOnceWith('keyboardEvent', { key: 'arrowRight' }));
         });
 
         it("shouldn't fire any event", function() {
@@ -105,7 +106,7 @@ describe('', function() {
             const event = new Event('keyup');
             event.key = undefined;
             // When
-            talkControlMaster._onKeyUp(event);
+            talkControlMaster.onKeyboardEvent(event);
             // Then
             assert(mainChannel.emit.notCalled);
         });

--- a/test/server/engines/revealjs-server-engine.spec.js
+++ b/test/server/engines/revealjs-server-engine.spec.js
@@ -4,7 +4,7 @@ import { stub } from 'sinon';
 import store from '@server/store';
 
 describe('RevealEngineServer', function() {
-    const slides = [{ h: 0, v: 0, f: 0, fMax: 3 }, { h: 1, v: 0, f: 0, fMax: 2 }, { h: 1, v: 1, f: 0, fMax: 2 }];
+    const slides = [{ h: 0, v: 0, f: -1, fMax: 3 }, { h: 1, v: 0, f: -1, fMax: 2 }, { h: 1, v: 1, f: -1, fMax: 2 }];
     let engine;
     beforeEach(function() {
         engine = new RevealEngine();
@@ -30,7 +30,7 @@ describe('RevealEngineServer', function() {
     describe('handleInput()', function() {
         it('should do nothing', function() {
             // Given
-            const currentSlide = { h: 0, v: 0, f: 0 };
+            const currentSlide = { h: 0, v: 0, f: -1 };
             stub(store, 'dispatch');
             stub(store, 'getState').returns({ currentSlide, slides });
             // When
@@ -43,7 +43,7 @@ describe('RevealEngineServer', function() {
 
         it('should call _nextFragment() on "arrowRight"', function() {
             // Given
-            const currentSlide = { h: 0, v: 0, f: 0 };
+            const currentSlide = { h: 0, v: 0, f: -1 };
             stub(engine, '_nextFragment');
             stub(store, 'getState').returns({ currentSlide, slides });
             // When
@@ -56,7 +56,7 @@ describe('RevealEngineServer', function() {
 
         it('should call _nextHorizontalSlide() on "arrowRight"', function() {
             // Given
-            const currentSlide = { h: 0, v: 0, f: 4 };
+            const currentSlide = { h: 0, v: 0, f: 2 };
             stub(engine, '_nextHorizontalSlide');
             stub(store, 'getState').returns({ currentSlide, slides });
             // When
@@ -69,7 +69,7 @@ describe('RevealEngineServer', function() {
 
         it('should call _prevFragment() on "arrowLeft"', function() {
             // Given
-            const currentSlide = { h: 0, v: 0, f: 3 };
+            const currentSlide = { h: 0, v: 0, f: 2 };
             stub(engine, '_prevFragment');
             stub(store, 'getState').returns({ currentSlide, slides });
             // When
@@ -82,7 +82,7 @@ describe('RevealEngineServer', function() {
 
         it('should call _prevHorizontalSlide() on "arrowLeft"', function() {
             // Given
-            const currentSlide = { h: 1, v: 0, f: 0 };
+            const currentSlide = { h: 1, v: 0, f: -1 };
             stub(engine, '_prevHorizontalSlide');
             stub(store, 'getState').returns({ currentSlide, slides });
             // When
@@ -108,7 +108,7 @@ describe('RevealEngineServer', function() {
 
         it('should call _prevVerticalSlide() on "arrowUp"', function() {
             // Given
-            const currentSlide = { h: 1, v: 1, f: 0 };
+            const currentSlide = { h: 1, v: 1, f: -1 };
             stub(engine, '_prevVerticalSlide');
             stub(store, 'getState').returns({ currentSlide, slides });
             // When
@@ -121,13 +121,13 @@ describe('RevealEngineServer', function() {
 
         it('should call _nextFragment() on "arrowDown"', function() {
             // Given
-            const currentSlide = { h: 0, v: 0, f: 0 };
+            const currentSlide = { h: 0, v: 0, f: -1 };
             stub(engine, '_nextFragment');
             stub(store, 'getState').returns({ currentSlide, slides });
             // When
             engine.handleInput({ key: 'arrowDown' });
             // Then
-            assert(engine._nextFragment.calledOnceWith({ h: 0, v: 0, f: 0 }));
+            assert(engine._nextFragment.calledOnceWith(currentSlide));
             store.getState.restore();
             engine._nextFragment.restore();
         });
@@ -147,7 +147,7 @@ describe('RevealEngineServer', function() {
 
         it('should call _nextFragment() on "space"', function() {
             // Given
-            const currentSlide = { h: 0, v: 0, f: 0 };
+            const currentSlide = { h: 0, v: 0, f: -1 };
             stub(engine, '_nextFragment');
             stub(store, 'getState').returns({ currentSlide, slides });
             // When

--- a/test/server/engines/revealjs-server-engine.spec.js
+++ b/test/server/engines/revealjs-server-engine.spec.js
@@ -80,17 +80,17 @@ describe('RevealEngineServer', function() {
             engine._prevFragment.restore();
         });
 
-        it('should call _prevHorizontalSlide() on "arrowLeft"', function() {
+        it('should call _prevSlide() on "arrowLeft"', function() {
             // Given
             const currentSlide = { h: 1, v: 0, f: -1 };
-            stub(engine, '_prevHorizontalSlide');
+            stub(engine, '_prevSlide');
             stub(store, 'getState').returns({ currentSlide, slides });
             // When
             engine.handleInput({ key: 'arrowLeft' });
             // Then
-            assert(engine._prevHorizontalSlide.calledOnceWith(currentSlide));
+            assert(engine._prevSlide.calledOnceWith({ h: 0, v: 0, f: -1, fMax: 3 }));
             store.getState.restore();
-            engine._prevHorizontalSlide.restore();
+            engine._prevSlide.restore();
         });
 
         it('should call _prevFragment() on "arrowUp"', function() {
@@ -106,17 +106,17 @@ describe('RevealEngineServer', function() {
             engine._prevFragment.restore();
         });
 
-        it('should call _prevVerticalSlide() on "arrowUp"', function() {
+        it('should call _prevSlide() on "arrowUp"', function() {
             // Given
             const currentSlide = { h: 1, v: 1, f: -1 };
-            stub(engine, '_prevVerticalSlide');
+            stub(engine, '_prevSlide');
             stub(store, 'getState').returns({ currentSlide, slides });
             // When
             engine.handleInput({ key: 'arrowUp' });
             // Then
-            assert(engine._prevVerticalSlide.calledOnceWith(currentSlide));
+            assert(engine._prevSlide.calledOnceWith({ h: 1, v: 0, f: -1, fMax: 2 }));
             store.getState.restore();
-            engine._prevVerticalSlide.restore();
+            engine._prevSlide.restore();
         });
 
         it('should call _nextFragment() on "arrowDown"', function() {

--- a/test/server/talk-control-server.spec.js
+++ b/test/server/talk-control-server.spec.js
@@ -25,7 +25,7 @@ describe('should have instantiated', function() {
             // Then
             assert(on.calledTwice, 'not called twice');
             assert(on.calledWith(MASTER_SERVER_CHANNEL, 'init'), 'not called with init');
-            assert(on.calledWith(MASTER_SERVER_CHANNEL, 'keyPressed'), 'not called with keypressed');
+            assert(on.calledWith(MASTER_SERVER_CHANNEL, 'keyboardEvent'), 'not called with keyboardEvent');
         });
     });
 


### PR DESCRIPTION
Based on #47.
**Expected Behavior**
- Default Revealjs shortcuts like 'Escape' should now work fine;
- You should be able to do some editing inside the slideshow

**How to reproduce**
- Start the app:
```bash
npm start
```
- Open your browser on `http://localhost:1234/__/layouts/on-stage/on-stage.html`
- Start the slideshow on `http://localhost:5000/reveal/demo`

You can try editing on 'Pretty Code' slide.

Closes #49 #48 #34 