### PR TITLE
Fix touch-pointer remove process

### DIFF
--- a/src/common/services/plugin.js
+++ b/src/common/services/plugin.js
@@ -20,8 +20,10 @@ module.exports = {
                 }
 
                 // Other plugins like bluetooth devices
-                plugin.instance.init();
-                plugin.instance.onEvent(event => controller.eventBusController.broadcast(CONTROLLER_SERVER_CHANNEL, plugin.instance.type, event));
+                if (!plugin.instance.initialized) {
+                    plugin.instance.init();
+                    plugin.instance.onEvent(event => controller.eventBusController.broadcast(CONTROLLER_SERVER_CHANNEL, plugin.instance.type, event));
+                }
             })
             .catch(e => console.error('Unable to load plugin module', e));
     },
@@ -35,8 +37,10 @@ module.exports = {
     activatePluginOnComponent(pluginName, component) {
         return loadPluginModule(pluginName)
             .then(plugin => {
-                plugin.instance.init();
-                plugin.instance.onEvent((type, event) => component.eventBusComponent.broadcast(CONTROLLER_COMPONENT_CHANNEL, type, event));
+                if (!plugin.instance.initialized) {
+                    plugin.instance.init();
+                    plugin.instance.onEvent((type, event) => component.eventBusComponent.broadcast(CONTROLLER_COMPONENT_CHANNEL, type, event));
+                }
             })
             .catch(e => console.error('Unable to load plugin module', e));
     }

--- a/src/plugins/input/keyboard/index.js
+++ b/src/plugins/input/keyboard/index.js
@@ -5,6 +5,7 @@ class KeyboardInput {
         this.usedByAComponent = true;
         this.type = 'inputEvent';
         this.callbacks = [];
+        this.initialized = false;
     }
 
     onEvent(callback) {
@@ -15,6 +16,7 @@ class KeyboardInput {
         addEventListener('keyup', e => this._captureKeyboardEvent.bind(this)(e, true), true);
         addEventListener('keypressed', this._captureKeyboardEvent.bind(this), true);
         addEventListener('keydown', this._captureKeyboardEvent.bind(this), true);
+        this.initialized = true;
     }
 
     _captureKeyboardEvent(event, forward = false) {

--- a/src/plugins/input/touch-pointer/index.js
+++ b/src/plugins/input/touch-pointer/index.js
@@ -7,6 +7,7 @@ class TouchPointerInput {
         this.pointer = { x: 0, y: 0, color: '#FF0000' };
         this.interval;
         this.messageEventRegistered = false;
+        this.initialized = false;
     }
 
     onEvent(callback) {
@@ -22,12 +23,14 @@ class TouchPointerInput {
             addEventListener('message', message => this._onMessageEvent(message));
             this.messageEventRegistered = true;
         }
+        this.initialized = true;
     }
 
     unload() {
         this._removeSettingsArea();
         this._removeMaskArea();
         this._removePointer();
+        this.initialized = false;
     }
 
     _addPointer() {
@@ -90,7 +93,7 @@ class TouchPointerInput {
             placeholder.style.display = 'block';
         }
     }
-    
+
     _removeArea(placeholderId) {
         const placeholder = document.getElementById(placeholderId);
 
@@ -103,7 +106,7 @@ class TouchPointerInput {
     _addSettingsArea() {
         this._addArea('<tc-touch-pointer-settings></tc-touch-pointer-settings>', 'placeholder1');
     }
-    
+
     _removeSettingsArea() {
         this._removeArea('placeholder1');
     }
@@ -111,7 +114,7 @@ class TouchPointerInput {
     _addMaskArea() {
         this._addArea('<tc-touch-pointer-mask></tc-touch-pointer-mask>', 'placeholder2');
     }
-    
+
     _removeMaskArea() {
         this._removeArea('placeholder2');
     }
@@ -135,7 +138,7 @@ class TouchPointerInput {
             this._setPointer(messageData.payload.x, messageData.payload.y);
             return;
         }
-        
+
         if (messageData.type === 'pointerColor') {
             this._setPointerColor(messageData.payload.color);
             return;

--- a/src/plugins/input/touch/index.js
+++ b/src/plugins/input/touch/index.js
@@ -9,6 +9,7 @@ class TouchInput {
             touchend: { clientX: 0, clientY: 0 }
         };
         this.callbacks = [];
+        this.initialized = false;
     }
 
     onEvent(callback) {
@@ -18,6 +19,7 @@ class TouchInput {
     init() {
         addEventListener('touchstart', this._captureTouchEvent.bind(this), false);
         addEventListener('touchend', e => this._captureTouchEvent.bind(this)(e, true), false);
+        this.initialized = true;
     }
 
     _captureTouchEvent(event, forward = false) {
@@ -26,14 +28,14 @@ class TouchInput {
                 clientX: event.changedTouches[0].clientX,
                 clientY: event.changedTouches[0].clientY
             };
-    
+
             if (forward) {
                 const xDiff = this.touchPosition.touchstart.clientX - this.touchPosition.touchend.clientX;
                 const yDiff = this.touchPosition.touchstart.clientY - this.touchPosition.touchend.clientY;
                 const xDiffPositive = xDiff < 0 ? xDiff * -1 : xDiff;
                 const yDiffPositive = yDiff < 0 ? yDiff * -1 : yDiff;
                 let action = '';
-                
+
                 if (xDiffPositive <= 20 && yDiffPositive <= 20) {
                     action = 'space';
                 } else if (xDiffPositive > yDiffPositive) {
@@ -41,7 +43,7 @@ class TouchInput {
                 } else if (yDiffPositive >= xDiffPositive) {
                     action = yDiff > 0 ? 'arrowDown' : 'arrowUp';
                 }
-                
+
                 for (const callBackMethod of this.callbacks) {
                     callBackMethod(this.type, { key: action });
                 }


### PR DESCRIPTION
The init method was called twice, resulting in the creation of 2 pointers, and the "remove" method only removes one of them, the one returned by getElementById which only returns the first element found.

This PR solves this issue by preventing plugins from being reinitialized.

Fixes #81 